### PR TITLE
fix(security): Resolve CodeQL alerts for untrusted code checkout

### DIFF
--- a/.github/workflows/ci-failure-fix.yml
+++ b/.github/workflows/ci-failure-fix.yml
@@ -21,9 +21,21 @@ jobs:
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request' &&
-      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-')
+      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-') &&
+      github.event.workflow_run.head_repository.full_name == github.repository
 
     steps:
+      - name: Verify not from fork
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const headRepo = '${{ github.event.workflow_run.head_repository.full_name }}';
+            const baseRepo = '${{ github.repository }}';
+            if (headRepo !== baseRepo) {
+              core.setFailed(`Refusing to run on forked PR code. Head: ${headRepo}, Base: ${baseRepo}`);
+            }
+            console.log(`Verified: ${headRepo} matches ${baseRepo}`);
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pr-comment-auto-triage.yml
+++ b/.github/workflows/pr-comment-auto-triage.yml
@@ -87,8 +87,8 @@ jobs:
       needs.detect-ai-agent.outputs.pr_number != ''
 
     steps:
-      - name: Get PR details
-        id: pr
+      - name: Verify PR is not from fork
+        id: security-check
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -100,18 +100,21 @@ jobs:
 
             const isSameRepo = pr.data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             if (!isSameRepo || pr.data.head.repo.fork) {
-              core.setFailed('Refusing to run auto-triage on forked PR code.');
+              core.setFailed('Refusing to run auto-triage on forked PR code for security reasons.');
               return;
             }
 
+            console.log(`Security check passed: PR is from same repo`);
+            core.setOutput('is_safe', 'true');
             core.setOutput('branch', pr.data.head.ref);
             core.setOutput('base', pr.data.base.ref);
             core.setOutput('title', pr.data.title);
 
       - name: Checkout PR branch
+        if: steps.security-check.outputs.is_safe == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.pr.outputs.branch }}
+          ref: ${{ steps.security-check.outputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,9 +140,9 @@ jobs:
 
             **PR Details:**
             - **Number:** #${{ needs.detect-ai-agent.outputs.pr_number }}
-            - **Title:** ${{ steps.pr.outputs.title }}
-            - **Branch:** ${{ steps.pr.outputs.branch }}
-            - **Base:** ${{ steps.pr.outputs.base }}
+            - **Title:** ${{ steps.security-check.outputs.title }}
+            - **Branch:** ${{ steps.security-check.outputs.branch }}
+            - **Base:** ${{ steps.security-check.outputs.base }}
 
             **AI Agent Comment:**
             ```
@@ -231,7 +234,7 @@ jobs:
             Auto-implemented by Claude PR Comment Triage workflow
             PR: #${{ needs.detect-ai-agent.outputs.pr_number }}"
 
-            git push origin ${{ steps.pr.outputs.branch }}
+            git push origin ${{ steps.security-check.outputs.branch }}
             ```
 
             ### 6. REPLY TO COMMENT
@@ -257,7 +260,7 @@ jobs:
             - ✅ Tests passing
             - ✅ Build successful
 
-            The fixes have been pushed to \`${{ steps.pr.outputs.branch }}\`.
+            The fixes have been pushed to \`${{ steps.security-check.outputs.branch }}\`.
 
             🤖 *Auto-implemented by Claude PR Comment Triage*
             EOF

--- a/.github/workflows/shortcut-rebase.yml
+++ b/.github/workflows/shortcut-rebase.yml
@@ -61,6 +61,13 @@ jobs:
               pull_number: prNumber
             });
 
+            // Security: Refuse to run on forked PRs
+            const isSameRepo = pr.data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            if (!isSameRepo || pr.data.head.repo.fork) {
+              core.setFailed('Refusing to run @rebase on forked PR code for security reasons.');
+              return;
+            }
+
             core.setOutput('pr_number', prNumber);
             core.setOutput('base_branch', pr.data.base.ref);
             core.setOutput('head_branch', pr.data.head.ref);

--- a/.github/workflows/shortcut-review.yml
+++ b/.github/workflows/shortcut-review.yml
@@ -55,6 +55,19 @@ jobs:
 
             core.setOutput('pr_number', prNumber);
 
+            // Security: Verify not from fork before proceeding
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const isSameRepo = pr.data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            if (!isSameRepo || pr.data.head.repo.fork) {
+              core.setFailed('Refusing to run @review on forked PR code for security reasons.');
+              return;
+            }
+
             // Add reaction to indicate processing
             if (context.payload.comment?.id) {
               await github.rest.reactions.createForIssueComment({


### PR DESCRIPTION
## Summary

Fixes 4 CodeQL security alerts for "Checkout of untrusted code in trusted context" in workflow files.

### Changes Made

1. **ci-failure-fix.yml**
   - Added job-level condition to skip when `head_repository.full_name != github.repository`
   - Added explicit verification step before checkout

2. **pr-comment-auto-triage.yml**
   - Renamed security check step to be explicit about its purpose
   - Added `is_safe` output that gates subsequent checkout
   - Added conditional `if: steps.security-check.outputs.is_safe == 'true'` to checkout

3. **shortcut-rebase.yml**
   - Added fork detection in the detect job before setting outputs
   - Fails early if PR is from a fork

4. **shortcut-review.yml**
   - Added fork detection with PR fetch before reaction
   - Fails early if PR is from a fork

### Security Impact

These workflows have elevated permissions (write access to contents, PRs, issues) and access to secrets. Without these checks, a malicious actor could:
- Create a fork with malicious code
- Open a PR from the fork
- The workflows would checkout and execute that untrusted code with elevated permissions

### Test Plan

- [x] All workflows validate that head repo matches base repo
- [x] All workflows explicitly fail when fork is detected
- [x] Checkout steps only run after security verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)