### PR TITLE
fix(deploy): add baseUrl for GitHub Pages and disable caching

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Build web app
         run: npx expo export --platform web
 
+      - name: Inject no-cache headers for staging
+        run: |
+          # Add no-cache meta tags to all HTML files for staging environment
+          find dist -name "*.html" -exec sed -i 's/<head>/<head>\n  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">\n  <meta http-equiv="Pragma" content="no-cache">\n  <meta http-equiv="Expires" content="0">/' {} \;
+          echo "Injected no-cache headers into $(find dist -name '*.html' | wc -l) HTML files"
+
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 

--- a/app.json
+++ b/app.json
@@ -48,7 +48,8 @@
       ]
     ],
     "experiments": {
-      "typedRoutes": true
+      "typedRoutes": true,
+      "baseUrl": "/thumbcode"
     },
     "extra": {
       "router": {


### PR DESCRIPTION
## Summary

Fixes two issues with the GitHub Pages staging deployment:

1. **Expo app not loading** - Added `experiments.baseUrl: "/thumbcode"` to app.json so Expo knows it's deployed under a subdirectory
2. **Browser caching old content** - Inject no-cache meta tags into HTML files during build

## Changes

- `app.json`: Add `experiments.baseUrl: "/thumbcode"` for GitHub Pages subdirectory deployment
- `.github/workflows/deploy-gh-pages.yml`: Add post-build step to inject cache-control meta tags

## Test Plan

- [ ] Verify staging deployment loads the Expo app (not stuck on spinner)
- [ ] Verify cache-busting works (fresh content on each deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the deployment workflow to automatically inject no-cache headers in staging builds, ensuring users consistently receive the latest version of the application without any unintended cached content interference
  * Added a new configurable base URL parameter to application settings, enabling improved routing capabilities and flexible resource loading configuration for enhanced application functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->