### PR TITLE
feat(docs): add landing page for docs site root

### DIFF
--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	<Card title="BYOK Security" icon="lock">
 		Bring Your Own Keys. Your API credentials stay on your device with hardware encryption.
 	</Card>
-	<Card title="Brand Identity" icon="star">
-		P3 "Warm Technical" design with organic paint daubes and the coral/teal/gold palette.
+	<Card title="Warm Design" icon="star">
+		A distinctive warm aesthetic with organic shapes and a coral/teal/gold palette.
 	</Card>
 </CardGrid>


### PR DESCRIPTION
## Summary
Adds a splash landing page at the docs root URL. Previously, visiting https://agentic-dev-library.github.io/thumbcode/ returned a 404 and users had to navigate to /introduction/.

## Changes
- Creates `docs-site/src/content/docs/index.mdx` with:
  - Hero section with tagline and CTA buttons
  - Feature cards highlighting Mobile-First, Multi-Agent, BYOK Security, and Brand Identity

## Test plan
- [ ] PR CI passes
- [ ] Docs site root URL shows landing page after merge

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive ThumbCode Documentation landing page showcasing core features: Mobile-First design, Multi-Agent System, BYOK Security, and Brand Identity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->