### PR TITLE
fix(ci): correct release-please-action SHA and upgrade to v4.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89f71c22407c941ceb6b4 # v4.2.0
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           release-type: node
           package-name: thumbcode


### PR DESCRIPTION
## Summary
- Fix corrupted SHA for `googleapis/release-please-action` that caused every Release workflow run to fail
- Upgrade from v4.2.0 to v4.4.0 (latest)
- Previous SHA `a02a34c4d625f9be7cb89f71c22407c941ceb6b4` was invalid — correct v4.2.0 SHA is `a02a34c4d625f9be7cb89156071d8567266a2445`

## Test plan
- [ ] Release workflow should succeed on push to main after merge
- [ ] release-please creates/updates a release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release automation tooling to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->