### PR TITLE
fix(ci): enable auto-merge for release-please PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.actor == 'dependabot[bot]' ||
-      github.actor == 'release-please[bot]'
+      github.actor == 'release-please[bot]' ||
+      github.actor == 'github-actions[bot]'
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,19 @@ jobs:
 
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           release-type: node
           package-name: thumbcode
+
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review "${{ steps.release.outputs.pr }}" --approve
+          gh pr merge "${{ steps.release.outputs.pr }}" --auto --squash
 
   build-apk:
     name: Build Android Debug APK


### PR DESCRIPTION
## Summary
- Add approve + auto-merge steps directly in `release.yml` after release-please creates a PR
- Update `automerge.yml` to also match `github-actions[bot]` actor
- Fixes release-please PRs not being auto-merged (GITHUB_TOKEN events don't trigger other workflows)

## Why this is needed
`release-please-action` uses `GITHUB_TOKEN`, so:
1. PRs are authored by `github-actions[bot]`, not `release-please[bot]`
2. The `pull_request` event from the PR never fires the `automerge.yml` workflow (GitHub's cascading prevention)

The fix handles auto-merge inline in `release.yml` where we already have the PR reference.

## Test plan
- [ ] Next push to main should have release-please enable auto-merge on PR #157
- [ ] Dependabot PRs should continue to auto-merge via `automerge.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced release automation to automatically merge release pull requests
* Extended workflow automation to support additional automated process triggers, improving CI/CD pipeline efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->