### PR TITLE
fix(ci): parse release-please PR JSON and split approve/merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,24 @@ jobs:
           release-type: node
           package-name: thumbcode
 
-      - name: Enable auto-merge on release PR
-        if: steps.release.outputs.pr
+      - name: Approve release PR
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
-          gh pr review "${{ steps.release.outputs.pr }}" --approve
-          gh pr merge "${{ steps.release.outputs.pr }}" --auto --squash
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr review "$PR_NUMBER" --approve
+        continue-on-error: true
+
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr merge "$PR_NUMBER" --auto --squash
 
   build-apk:
     name: Build Android Debug APK


### PR DESCRIPTION
## Summary
- Extract PR number from release-please JSON output using `jq`
- Split approve and auto-merge into separate steps
- Add `continue-on-error` on approve (GITHUB_TOKEN can't self-approve)
- Use `prs_created == 'true'` conditional instead of raw `pr` output

Fixes the "Enable auto-merge on release PR" step that failed because `steps.release.outputs.pr` is a JSON object, not a PR number.

## Test plan
- [ ] Release workflow should successfully enable auto-merge on release PR #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)