### PR TITLE
fix(ci): add checkout step before release PR auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,24 @@ jobs:
           release-type: node
           package-name: thumbcode
 
-      - name: Enable auto-merge on release PR
-        if: steps.release.outputs.pr
+      - name: Approve release PR
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
-          gh pr review "${{ steps.release.outputs.pr }}" --approve
-          gh pr merge "${{ steps.release.outputs.pr }}" --auto --squash
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr review "$PR_NUMBER" --approve
+        continue-on-error: true
+
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr merge "$PR_NUMBER" --auto --squash
 
   build-apk:
     name: Build Android Debug APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
           release-type: node
           package-name: thumbcode
 
+      - name: Checkout code
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Approve release PR
         if: steps.release.outputs.prs_created == 'true'
         env:


### PR DESCRIPTION
## Summary
- Add `actions/checkout` before the approve/merge steps in release.yml
- Fixes `fatal: not a git repository` error when `gh pr merge` runs

The `gh` CLI requires a git repository context. The release-please job doesn't checkout the repo by default since it only calls the API.

## Test plan
- [ ] Release workflow should auto-merge PR #157 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal release workflow automation to ensure proper code checkout during release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->