### PR TITLE
fix(ci): use CI_GITHUB_TOKEN for release-please, label-based automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: Automerge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: write
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.actor == 'dependabot[bot]' ||
-      github.actor == 'release-please[bot]' ||
-      github.actor == 'github-actions[bot]'
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,24 @@ jobs:
           release-type: node
           package-name: thumbcode
 
-      - name: Enable auto-merge on release PR
-        if: steps.release.outputs.pr
+      - name: Approve release PR
+        if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
-          gh pr review "${{ steps.release.outputs.pr }}" --approve
-          gh pr merge "${{ steps.release.outputs.pr }}" --auto --squash
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr review "$PR_NUMBER" --approve
+        continue-on-error: true
+
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr merge "$PR_NUMBER" --auto --squash
 
   build-apk:
     name: Build Android Debug APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
 
     steps:
@@ -23,31 +23,9 @@ jobs:
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
           release-type: node
           package-name: thumbcode
-
-      - name: Checkout code
-        if: steps.release.outputs.prs_created == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Approve release PR
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          gh pr review "$PR_NUMBER" --approve
-        continue-on-error: true
-
-      - name: Enable auto-merge on release PR
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          gh pr merge "$PR_NUMBER" --auto --squash
 
   build-apk:
     name: Build Android Debug APK


### PR DESCRIPTION
## Summary
- Use org-level `CI_GITHUB_TOKEN` PAT for release-please-action
- Remove inline approve/merge/checkout workaround from release.yml (PAT makes events trigger workflows naturally)
- Switch automerge.yml from actor-based to label-based detection (`autorelease: pending` label)
- Added `labeled` to automerge PR event types
- Deleted stale repo secrets: `SONAR_TOKEN`, `EXPO_TOKEN`, `COVERALLS_REPO_TOKEN`

## Why
With `GITHUB_TOKEN`, release-please's events don't trigger workflows (GitHub cascading prevention). With the org PAT, the full flow works end-to-end:
1. Push to main → release-please creates PR (attributed to PAT user) → triggers automerge workflow
2. Automerge detects `autorelease: pending` label → approves + merges
3. Merged PR push → triggers release-please again → creates GitHub release
4. `release: published` → triggers APK build

## Test plan
- [ ] Next conventional commit push to main should trigger full release flow
- [ ] Dependabot PRs should still auto-merge via actor check

🤖 Generated with [Claude Code](https://claude.com/claude-code)