### PR TITLE
fix: type compatibility for dep upgrades, automerge PAT

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: Enable automerge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge "$PR_URL" --auto --squash

--- a/src/core/git/GitHttpClient.ts
+++ b/src/core/git/GitHttpClient.ts
@@ -43,7 +43,7 @@ export const gitHttpClient = {
     const res = await secureFetch(url, {
       method,
       headers,
-      body: body ? new Blob(body) : undefined,
+      body: body ? new Blob(body as BlobPart[]) : undefined,
     });
 
     const responseHeaders: Record<string, string> = {};

--- a/src/services/ai/openai-helpers.ts
+++ b/src/services/ai/openai-helpers.ts
@@ -95,6 +95,8 @@ export function parseOpenAIContent(
 
   if (message.tool_calls) {
     for (const toolCall of message.tool_calls) {
+      if (toolCall.type !== 'function') continue;
+
       let parsedInput: Record<string, unknown> = {};
       try {
         parsedInput = JSON.parse(toolCall.function.arguments);


### PR DESCRIPTION
## Summary
- **GitHttpClient**: Cast `Uint8Array[]` to `BlobPart[]` for stricter TypeScript types (fixes PR #154 minor-and-patch CI)
- **openai-helpers**: Guard `toolCall.type === 'function'` before accessing `.function` property (fixes PR #149 OpenAI v6 CI)
- **automerge.yml**: Use `CI_GITHUB_TOKEN` (PAT) for the merge step so release-please PR merges trigger downstream release workflows (fixes v1.0.2 not releasing)

## Context
Three dependabot PRs (#148, #149, #154) are failing CI due to type incompatibilities with newer dependency versions. This PR makes the code forward-compatible while remaining backward-compatible with current versions.

The automerge fix resolves the issue where merging release-please PRs with GITHUB_TOKEN doesn't trigger the release workflow (GitHub's cascading prevention).

## Test plan
- [x] `pnpm run typecheck` passes locally
- [ ] CI passes on this PR
- [ ] After merge, dependabot PRs #149 and #154 rebase and pass CI
- [ ] Next release-please PR merge triggers v1.0.2 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication method for automated merge operations.
  * Improved type safety in HTTP client request handling.

* **Bug Fixes**
  * Enhanced AI tool call processing to correctly filter and handle specific call types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->